### PR TITLE
Mark VPP as inactive

### DIFF
--- a/radar.json
+++ b/radar.json
@@ -328,7 +328,7 @@
       "label": "VPP",
       "quadrant": 1,
       "ring": 3,
-      "active": "TRUE",
+      "active": "FALSE",
       "moved": 0
     },
     {


### PR DESCRIPTION
# Motivation
VPP is no longer in active use at emnify.

# Description
Set `active: "FALSE"` on the VPP entry. It remains visible on the radar in the ON HOLD ring but will be rendered as inactive (greyed out).