### PR TITLE
chore: add missing platform and data tooling to the radar

### DIFF
--- a/radar.json
+++ b/radar.json
@@ -94,7 +94,7 @@
       "moved": 0
     },
     {
-      "label": "DBT (Cloud)",
+      "label": "DBT",
       "quadrant": 3,
       "ring": 0,
       "active": "TRUE",

--- a/radar.json
+++ b/radar.json
@@ -584,6 +584,20 @@
       "moved": 2
     },
     {
+      "label": "Apache Airflow",
+      "quadrant": 3,
+      "ring": 0,
+      "active": "TRUE",
+      "moved": 2
+    },
+    {
+      "label": "StarRocks",
+      "quadrant": 3,
+      "ring": 0,
+      "active": "TRUE",
+      "moved": 2
+    },
+    {
       "label": "AWS Application Load Balancer",
       "quadrant": 2,
       "ring": 0,

--- a/radar.json
+++ b/radar.json
@@ -171,6 +171,20 @@
       "moved": 0
     },
     {
+      "label": "Kafka Connect",
+      "quadrant": 3,
+      "ring": 0,
+      "active": "TRUE",
+      "moved": 2
+    },
+    {
+      "label": "Debezium",
+      "quadrant": 3,
+      "ring": 0,
+      "active": "TRUE",
+      "moved": 2
+    },
+    {
       "label": "Github Actions",
       "quadrant": 0,
       "ring": 0,
@@ -185,6 +199,13 @@
       "moved": 0
     },
     {
+      "label": "OpenTelemetry",
+      "quadrant": 0,
+      "ring": 0,
+      "active": "TRUE",
+      "moved": 2
+    },
+    {
       "label": "Jenkins",
       "quadrant": 0,
       "ring": 0,
@@ -193,6 +214,13 @@
     },
     {
       "label": "ArgoCD",
+      "quadrant": 0,
+      "ring": 0,
+      "active": "TRUE",
+      "moved": 2
+    },
+    {
+      "label": "Helm",
       "quadrant": 0,
       "ring": 0,
       "active": "TRUE",
@@ -267,6 +295,20 @@
       "ring": 0,
       "active": "TRUE",
       "moved": 1
+    },
+    {
+      "label": "Karpenter",
+      "quadrant": 2,
+      "ring": 0,
+      "active": "TRUE",
+      "moved": 2
+    },
+    {
+      "label": "Envoy",
+      "quadrant": 2,
+      "ring": 0,
+      "active": "TRUE",
+      "moved": 2
     },
     {
       "label": "AWS Transit Gateway",

--- a/radar.json
+++ b/radar.json
@@ -173,9 +173,9 @@
     {
       "label": "Github Actions",
       "quadrant": 0,
-      "ring": 3,
+      "ring": 0,
       "active": "TRUE",
-      "moved": 0
+      "moved": 1
     },
     {
       "label": "Grafana LGTM Stack",
@@ -190,6 +190,13 @@
       "ring": 0,
       "active": "TRUE",
       "moved": 0
+    },
+    {
+      "label": "ArgoCD",
+      "quadrant": 0,
+      "ring": 0,
+      "active": "TRUE",
+      "moved": 2
     },
     {
       "label": "Prometheus",


### PR DESCRIPTION
# Motivation

We introduced a fair amount of tech in the last six months that never made it onto the radar, and a couple of entries no longer describe how we actually run things. Someone using the radar to understand our stack would not learn how we deploy to Kubernetes, how data gets from PCDB into the enriched services, how we orchestrate batch pipelines, or how we trace requests.

No hard process around the radar, so this is a sweep rather than a formal review — corrections welcome.

# Description

**Added — 9 entries, all ADOPT, marked new (`moved: 2`)**

| Entry | Quadrant | Why |
| --- | --- | --- |
| ArgoCD | Platform & Tools | Deploys four EKS clusters carrying production workloads on both instances — app-of-apps plus an ApplicationSet discovering repos by label |
| Helm | Platform & Tools | `kafka-streaming-helm-chart`, plus a central `helm-lint` reusable workflow |
| OpenTelemetry | Platform & Tools | Direct dependency in squirrel (`go.opentelemetry.io/otel` 1.44.0, `sdk`, `trace`) with documented span-tree and propagation conventions |
| Kafka Connect | Data Storage & Processing | The sink/source fleet — 15 sink connectors on prod-emnify alone |
| Debezium | Data Storage & Processing | `pcdb.cdc.*`, the CDC backbone feeding every enriched service |
| Apache Airflow | Data Storage & Processing | Orchestration core of the batch pipelines (via @nicor88) |
| StarRocks | Data Storage & Processing | Query engine on the lakehouse (via @nicor88) |
| Karpenter | Infrastructure & Network | Node provisioning — `nxpg-eks` `components/eks-cluster/karpenter.tf` |
| Envoy | Infrastructure & Network | squirrel-proxy sidecar, with its own Grafana dashboard and deploy-pipeline wiring |

**Changed — 2 entries**

- `Github Actions` **ON HOLD → ADOPT** (`moved: 1`). `github-resources` publishes 21 central reusable workflows — container builds via mvn/sbt jib, helm lint, backstage lint, terraform plan and apply, TechDocs publishing — and the repos sampled (squirrel, EMB, enriched-sim-service, nxpg-eks, monitoring-pgw, probe-openvpn, grafana) carry three to six workflows each.
- `DBT (Cloud)` → **`DBT`** (@nicor88). Not a label tidy: we no longer use the managed product, it is self-hosted on the data platform directly.

**Checked and deliberately unchanged:** Kafka Streams and Scala are already on the radar at ADOPT, and the Akka ON HOLD / Pekko TRIAL pair correctly reflects the licence migration. `Apache Iceberg` was already present too.

JSON validated at each step; 78 → 87 entries, no reformatting of the rest of the file.

# Worth a reviewer opinion

- **Three ADOPT entries now sit in the deployment space** — Jenkins, GitHub Actions and ArgoCD. Accurate rather than contradictory, since they do different jobs, but the radar has no way to express the division.
- **Apache Airflow alongside AWS Step Functions** raises the same question. @nicor88's framing is the useful one: Step Functions is AWS-native workflow, Airflow is the orchestration core of the batch pipelines.
- **Helm and Karpenter** could be argued as implementation detail of `AWS EKS`, which is already listed.

Happy to narrow any of these if the team would rather draw sharper lines.